### PR TITLE
Ensure Vercel function bundles Remix server build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,9 @@
 {
+  "functions": {
+    "api/render.ts": {
+      "includeFiles": "build/**"
+    }
+  },
   "routes": [
     { "handle": "filesystem" },
     { "src": "/(.*)", "dest": "/api/render" }


### PR DESCRIPTION
## Summary
- include the Remix build directory when bundling the Vercel serverless handler so the server build can be imported at runtime

## Testing
- `tsc`
- `eslint --cache --cache-location ./node_modules/.cache/eslint app`


------
https://chatgpt.com/codex/tasks/task_e_68e375da64e0832b8a116836f6b0c9cf