### PR TITLE
Fix Vercel function pattern and support generated build types

### DIFF
--- a/functions/[[path]].ts
+++ b/functions/[[path]].ts
@@ -2,6 +2,7 @@ import type { ServerBuild } from '@remix-run/cloudflare';
 import { createPagesFunctionHandler } from '@remix-run/cloudflare-pages';
 
 export const onRequest: PagesFunction = async (context) => {
+  // @ts-expect-error - the Remix server build is generated at deploy time
   const serverBuild = (await import('../build/server')) as unknown as ServerBuild;
 
   const handler = createPagesFunctionHandler({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
   "include": [
     "**/*.ts",
     "**/*.tsx",
+    "**/*.d.ts",
     "**/.server/**/*.ts",
     "**/.server/**/*.tsx",
     "**/.client/**/*.ts",

--- a/types/remix-server-build.d.ts
+++ b/types/remix-server-build.d.ts
@@ -1,0 +1,6 @@
+declare module '../build/server' {
+  import type { ServerBuild } from '@remix-run/cloudflare';
+
+  const build: ServerBuild;
+  export default build;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,8 @@
 {
   "functions": {
-    "api/*.ts": {
-      "includeFiles": "build/**"
+    "api/render.ts": {
+      "includeFiles": "build/**",
+      "runtime": "nodejs20.x"
     }
   },
   "routes": [

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,9 @@
 {
+  "functions": {
+    "api/*.ts": {
+      "includeFiles": "build/**"
+    }
+  },
   "routes": [
     { "handle": "filesystem" },
     { "src": "/(.*)", "dest": "/api/render" }


### PR DESCRIPTION
## Summary
- broaden the Vercel function glob so the Remix handler is detected during deployment
- add a type declaration for the generated Remix server build and include declaration files in the TypeScript config
- document the dynamic import of the server build for Cloudflare Pages by suppressing the expected type error

## Testing
- `pnpm typecheck`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68e375da64e0832b8a116836f6b0c9cf